### PR TITLE
Issue8 auth bugs

### DIFF
--- a/pyFireEye/ax/__init__.py
+++ b/pyFireEye/ax/__init__.py
@@ -7,16 +7,16 @@ class AX:
 
     """
 
-    def __init__(self, ax_host, ax_port=None, verify=False, token_auth=False, username="", password=""):
+    def __init__(self, ax_host, ax_port=None, verify=False, token_auth=False, username="", password="", token=""):
 
         if not verify:
             import requests
             from requests.packages.urllib3.exceptions import InsecureRequestWarning
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
-        self._authenticator = Authentication(ax_host=ax_host, ax_port=ax_port, verify=verify, token_auth=token_auth, username=username, password=password)
-        if username and password:
-            self._authenticator.authenticate(username=username, password=password)
+        self._authenticator = Authentication(ax_host=ax_host, ax_port=ax_port, verify=verify, token_auth=token_auth, username=username, password=password, token=token)
+        if username and password and not token:
+            self._authenticator.authenticate(username=username, password=password, token_auth=token_auth)
         self.alerts = Alerts(ax_host=ax_host, ax_port=ax_port, verify=verify, authenticator=self._authenticator)
         self.submissions = Submission(ax_host=ax_host, ax_port=ax_port, verify=verify, authenticator=self._authenticator)
         self.reports = Reports(ax_host=ax_host, ax_port=ax_port, verify=verify, authenticator=self._authenticator)
@@ -26,12 +26,15 @@ class AX:
         self.custom_ioc = CustomIOC(ax_host=ax_host, ax_port=ax_port, verify=verify, authenticator=self._authenticator)
 
     def reauth(self):
-        return self._authenticator.authenticate()
+        if self._authenticator.token_auth:
+            self._authenticator.authenticate(token_auth=True)
 
     def authenticate(self, username, password, token_auth=None):
-        """ """
-        return self._authenticator.authenticate(username=username, password=password, token_auth=token_auth)
+        self._authenticator.authenticate(username=username, password=password, token_auth=token_auth)
 
     def logout(self):
-        """ """
-        return self._authenticator.logout()
+        if self._authenticator.token:
+            token_auth = self._authenticator.token_auth
+            self._authenticator.token_auth = True
+            self._authenticator.logout()
+            self._authenticator.token_auth = token_auth

--- a/pyFireEye/ax/ax_core.py
+++ b/pyFireEye/ax/ax_core.py
@@ -117,12 +117,15 @@ class Authentication(_AX):
 
     @expected_response(expected_status_code=204, expected_format=DEFAULT)
     @template_request(method="POST", route="/auth/logout")
-    def logout(self, **kwargs):
+    def logout(self, token=None, **kwargs):
         """
-
+        :param token: optional token to logout. if not provided will logout class's stored auth token
         :param kwargs:
         :return:
         """
+        if token:
+            kwargs["headers"][self.TOKEN_HEADER] = token
+
         return self._base_request(**kwargs)
 
 

--- a/pyFireEye/cms/__init__.py
+++ b/pyFireEye/cms/__init__.py
@@ -7,25 +7,28 @@ class CMS:
 
     """
 
-    def __init__(self, cms_host, cms_port=None, verify=False, token_auth=False, username="", password=""):
+    def __init__(self, cms_host, cms_port=None, verify=False, token_auth=False, username="", password="", token=""):
 
         if not verify:
             import requests
             from requests.packages.urllib3.exceptions import InsecureRequestWarning
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
-        self._authenticator = Authentication(cms_host=cms_host, cms_port=cms_port, verify=verify, token_auth=token_auth, username=username, password=password)
-        if username and password:
-            self._authenticator.authenticate(username=username, password=password)
+        self._authenticator = Authentication(cms_host=cms_host, cms_port=cms_port, verify=verify, token_auth=token_auth, username=username, password=password, token=token)
+        if username and password and not token:
+            self._authenticator.authenticate(username=username, password=password, token_auth=token_auth)
         self.alerts = Alerts(cms_host=cms_host, cms_port=cms_port, verify=verify, authenticator=self._authenticator)
 
     def reauth(self):
-        return self._authenticator.authenticate()
+        if self._authenticator.token_auth:
+            self._authenticator.authenticate(token_auth=True)
 
     def authenticate(self, username, password, token_auth=None):
-        """ """
-        return self._authenticator.authenticate(username=username, password=password, token_auth=token_auth)
+        self._authenticator.authenticate(username=username, password=password, token_auth=token_auth)
 
     def logout(self):
-        """ """
-        return self._authenticator.logout()
+        if self._authenticator.token:
+            token_auth = self._authenticator.token_auth
+            self._authenticator.token_auth = True
+            self._authenticator.logout()
+            self._authenticator.token_auth = token_auth

--- a/pyFireEye/cms/cms_core.py
+++ b/pyFireEye/cms/cms_core.py
@@ -88,7 +88,14 @@ class Authentication(_CMS):
 
     @expected_response(expected_status_code=204, expected_format=DEFAULT)
     @template_request(method="POST", route="/auth/logout")
-    def logout(self, **kwargs):
+    def logout(self, token=None, **kwargs):
+        """
+        :param token: optional token to logout. if not provided will logout class's stored auth token
+        :param kwargs:
+        :return:
+        """
+        if token:
+            kwargs["headers"][self.TOKEN_HEADER] = token
 
         return self._base_request(**kwargs)
 

--- a/pyFireEye/cms/cms_core.py
+++ b/pyFireEye/cms/cms_core.py
@@ -42,11 +42,13 @@ class Authentication(_CMS):
     BASIC_HEADER = "Authorization"
     token = ""
 
-    def __init__(self, cms_host, cms_port=None, verify=False, token_auth=False, username="", password=""):
+    def __init__(self, cms_host, cms_port=None, verify=False, token_auth=False, username="", password="", token=""):
         _CMS.__init__(self, cms_host, cms_port=cms_port, verify=verify)
         self.username = username
         self.password = password
-        self.token_auth = token_auth
+        self.token = token
+        self.token_auth = True if token_auth else False or True if self.token else False
+        self.AUTHENTICATION = self
 
     def get_auth_header(self):
 
@@ -63,15 +65,20 @@ class Authentication(_CMS):
             self.username = username
             self.password = password
 
-        if not self.username or not self.password:
-            raise InsufficientCredentialsException("username", "password")
+        if self.token_auth:
+            if self.token:
+                self.logout()
+            response = self.auth(self.username, self.password)
+            if isinstance(response, ErrorResponse):
+                raise FireEyeError(response)
 
-        response = self.auth(self.username, self.password)
-        if isinstance(response, ErrorResponse):
-            raise FireEyeError(response)
-
-        self.token = response.headers[self.TOKEN_HEADER]
-        self.AUTHENTICATION = self
+            self.token = response.headers[self.TOKEN_HEADER]
+        else:
+            if self.token:
+                self.token_auth = True
+                self.logout()
+                self.token_auth = False
+            self.token = None
 
     @expected_response(expected_status_code=200, expected_format=DEFAULT)
     @template_request(method="POST", route="/auth/login", require_auth=False)

--- a/pyFireEye/faas/__init__.py
+++ b/pyFireEye/faas/__init__.py
@@ -10,18 +10,18 @@ class FaaS:
 
     """
 
-    def __init__(self, verify=False, token_auth=False, api_key="", api_secret=""):
+    def __init__(self, verify=False, api_key="", api_secret="", token=""):
 
         if not verify:
             import requests
             from requests.packages.urllib3.exceptions import InsecureRequestWarning
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
-        self._authenticator = Authentication(verify=verify, token_auth=token_auth, api_key=api_key, api_secret=api_secret)
-        if api_secret and api_key:
+        self._authenticator = Authentication(verify=verify, api_key=api_key, api_secret=api_secret, token=token)
+        if api_secret and api_key and not token:
             self._authenticator.authenticate(api_key=api_key, api_secret=api_secret)
         self.investigations = Investigations(verify=verify, authenticator=self._authenticator)
 
-        def authenticate(self, api_key, api_secret, token_auth=False):
+    def authenticate(self, api_key, api_secret):
 
-            return self._authenticator.authenticate(api_key=api_key, api_secret=api_secret, token_auth=token_auth)
+        return self._authenticator.authenticate(api_key=api_key, api_secret=api_secret)

--- a/pyFireEye/faas/faas_core.py
+++ b/pyFireEye/faas/faas_core.py
@@ -42,45 +42,40 @@ class Authentication(_FaaS):
     AUTH_HEADER = "Authorization"
     token = ""
 
-    def __init__(self, verify=False, token_auth=False, api_key="", api_secret=""):
+    def __init__(self, verify=False, api_key="", api_secret="", token=""):
 
         _FaaS.__init__(self, verify=verify)
-        self.token_auth = token_auth
         self.api_key = api_key
         self.api_secret = api_secret
+        if token:
+            self.token = token
+        self.AUTHENTICATION = self
 
     def get_auth_header(self):
 
-        if self.token_auth:
-            return self.AUTH_HEADER, "Bearer {}".format(self.token)
-        else:
-            encoded = b64encode_wrap(self.api_key + ":" + self.api_secret)
-            return self.AUTH_HEADER, """Basic {}""".format(encoded)
+        return self.AUTH_HEADER, "Bearer {}".format(self.token)
 
-    def authenticate(self, api_key="", api_secret="", token_auth=None):
+    def authenticate(self, api_key="", api_secret=""):
 
-        if isinstance(token_auth, bool):
-            self.token_auth = token_auth
-        if api_key and api_secret:
+        if api_key:
             self.api_key = api_key
+        if api_secret:
             self.api_secret = api_secret
-        else:
-            raise InsufficientCredentialsException("api_key", "api_secret")
-
-        self.AUTHENTICATION = self
 
         response = self.auth(self.api_key, self.api_secret)
         if isinstance(response, ErrorResponse):
             raise FireEyeError(response)
 
         self.token = response.json()["content"]["access_token"]
-        self.token_auth = True
 
     @expected_response(expected_status_code=200, expected_format=JSON)
-    @template_request(method="POST", route="/token")
-    def auth(self, api_key, api_secret, **kwargs):
-
+    @template_request(method="POST", route="/token", require_auth=False)
+    def auth(self, api_key="", api_secret="", **kwargs):
+        if not api_key or not api_secret:
+            raise InsufficientCredentialsException("api_key", "api_secret")
+        encoded = b64encode_wrap(api_key + ":" + api_secret)
         kwargs["data"] = {"grant_type": "client_credentials"}
+        kwargs["headers"].update({self.AUTH_HEADER: "Basic {}".format(encoded)})
         kwargs["headers"].update({"Content-Type": "application/x-www-form-urlencoded", "Cache-Control": "no-cache"})
         return self._base_request(**kwargs)
 

--- a/pyFireEye/hx/hx_core.py
+++ b/pyFireEye/hx/hx_core.py
@@ -146,12 +146,15 @@ class Authentication(_HX):
 
     @expected_response(expected_status_code=204, expected_format=DEFAULT)
     @template_request(method="DELETE", route="/token")
-    def logout(self, **kwargs):
+    def logout(self, token=None, **kwargs):
         """
-        logout an existing token if using token auth
-        :param kwargs: passthrough from template request
-        :return: response if token auth, None otherwise
+        :param token: optional token to logout. if not provided will logout class's stored auth token
+        :param kwargs:
+        :return:
         """
+        if token:
+            kwargs["headers"][self.TOKEN_HEADER] = token
+
         return self._base_request(**kwargs)
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read_requirements():
 
 
 setup(
-    version="1.0.2",
+    version="1.0.3",
     name="pyFireEye",
     description="Python API bindings for FireEye Products",
     long_description="",


### PR DESCRIPTION
#8 
this should fix the issues with token creation when trying to use basic auth. 

This has been tested against hx. ax, and cms use the same auth scheme so should work. 

reauth() now assumes token auth. 

authenticate() will automatically logout an existing token if called, token_auth or no

can now provide a token to start with if desired
